### PR TITLE
Added the ability to toggle showing details of success/failed/skipped…

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,21 @@ module.exports = function(config) {
 **Default:** `true`  
 **Description:** Determines whether the results are split into a separate file for each browser.  
 
+#### showSuccess
+**Type:** Boolean  
+**Default:** `true`  
+**Description:** Determines whether the detailed results of the successfull tests are default shown or hidden in the browser (you are able to toggle live in the browser)
+
+#### showFailed
+**Type:** Boolean  
+**Default:** `true`  
+**Description:** Determines whether the detailed results of the failed tests are default shown or hidden in the browser (you are able to toggle live in the browser)
+
+#### showSkipped
+**Type:** Boolean  
+**Default:** `true`  
+**Description:** Determines whether the detailed results of the skipped tests are default shown or hidden in the browser (you are able to toggle live in the browser)
+
 #### useHostedBootstrap
 **Type:** Boolean  
 **Default:** `false`  

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -15,6 +15,9 @@ var HtmlDetailedReporter = function (baseReporterDecorator, config, logger, help
     var outputDir = helper.normalizeWinPath(path.resolve(config.basePath, reporterConfig.dir || '_reports/'));
     var autoReload = (reporterConfig.autoReload == null || reporterConfig.autoReload == undefined) ? true : reporterConfig.autoReload == false ? false : true;
     var refreshTimeout = reporterConfig.refreshTimeout <= 0 ? 0 : !!reporterConfig.refreshTimeout ? reporterConfig.refreshTimeout : 1000;
+    var showSuccess = (reporterConfig.showSuccess == null || reporterConfig.showSuccess == undefined) ? true : reporterConfig.showSuccess == false ? false : true;
+    var showFailed = (reporterConfig.showFailed == null || reporterConfig.showFailed == undefined) ? true : reporterConfig.showFailed == false ? false : true;
+    var showSkipped = (reporterConfig.showSkipped == null || reporterConfig.showSkipped == undefined) ? true : reporterConfig.showSkipped == false ? false : true;
 
     var splitResults;
     if (reporterConfig.splitResults == undefined || reporterConfig.splitResults == null)
@@ -211,6 +214,13 @@ var HtmlDetailedReporter = function (baseReporterDecorator, config, logger, help
             template = template.replace(/\{\{Browser\}\}/g, '');
             counts = getCounts();
         }
+
+        var json = {
+            success: showSuccess,
+            danger: showFailed,
+            active: showSkipped
+        };
+        template = template.replace(/\{\{DefaultVisibilityStates\}\}/g, JSON.stringify(json));
 
         // Replace remaining placeholders
         template = template.replace('{{Auto_Reload}}', autoReload);

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -336,7 +336,7 @@ var HtmlDetailedReporter = function (baseReporterDecorator, config, logger, help
 
             if (result.skipped) {
                 skipCnt[browser]++;
-                row.att('class', 'active');
+                row.att('class', 'active' + (showSkipped ? '' : ' hide'));
                 statusCell.att('class', 'status');
                 statusCell.text('Skipped');
 
@@ -345,7 +345,7 @@ var HtmlDetailedReporter = function (baseReporterDecorator, config, logger, help
             }
             else if (result.success) {
                 passCnt[browser]++;
-                row.att('class', 'success');
+                row.att('class', 'success' + (showSuccess ? '' : ' hide'));
                 statusCell.att('class', 'status');
                 statusCell.text('Passed');
 
@@ -354,7 +354,7 @@ var HtmlDetailedReporter = function (baseReporterDecorator, config, logger, help
             }
             else {
                 failCnt[browser]++;
-                row.att('class', 'danger');
+                row.att('class', 'danger' + (showFailed ? '' : ' hide'));
                 expandCell.att('rowspan', '2');
                 statusCell.att('class', 'status');
                 statusCell.att('rowspan', '2');

--- a/template.html
+++ b/template.html
@@ -33,6 +33,7 @@
         <script src="{{jquery_Path}}/jquery.min.js"></script>
         <script>
             var reload = shouldReload();
+            var visibleStates = {{DefaultVisibilityStates}};
 
             function shouldReload() {
                 if (location.search != null && location.search != undefined && location.search.length > 0)
@@ -59,9 +60,65 @@
                 }
             };
 
-            $(document).ready(function() {
-                setState(!reload);                
+            var loadValuesFromStorage = function(){
+                try{
+                    var value =  JSON.parse(localStorage['VisibleStates']);
+                    visibleStates = value || visibleStates;
+                }catch(e){
+                    //For some reason we don't support local getValueFromLocalStorage
+                    //Old version of IE?
+                }
+            }
 
+            var saveValueInStorage = function(){
+                try{
+                    localStorage['VisibleStates'] = JSON.stringify(visibleStates);
+                }catch(e){
+                    //For some reason we don't support local getValueFromLocalStorage
+                    //Old version of IE?
+                }
+            }
+
+            var toggleHiddenState = function(){
+                var id = $(this).attr('id');
+                if(!id || !visibleStates.hasOwnProperty(id)) return;
+                visibleStates[id] = !visibleStates[id];
+                displayItems(id);
+                saveValueInStorage();
+            }
+
+            var displayItems = function(id){
+                var visible = visibleStates[id];
+                var eye = $('span', '#'+ id);
+                var items = $(('.' + id), '.whiteout');
+
+                var openEye = 'glyphicon-eye-open';
+                var closedEye = 'glyphicon-eye-close';
+
+                if(visible) {
+                    items.removeClass('hide');
+                    eye.removeClass(closedEye);
+
+                    eye.addClass(openEye);
+                }
+                else {
+                    eye.removeClass(openEye);
+
+                    items.addClass('hide');
+                    eye.addClass(closedEye);
+                }
+            }
+
+            $(document).ready(function() {
+                setState(!reload);
+                loadValuesFromStorage();
+
+                for(name in visibleStates){
+                    displayItems(name);
+                }
+
+                $('.countBox').click(toggleHiddenState);
+                
                 $('#refreshBtn').click(function() {
                     setState(reload);
                     if (reload) {
@@ -110,21 +167,24 @@
                         </div>
                     </div>
                     <div class="col-sm-2 col-sm-offset-1">
-                        <div class="countBox success">
+                        <div class="countBox success" id="success">
                             <h2>{{Total_Pass_Count}}</h2>
                             Passed Tests
+                            <span class="glyphicon glyphicon-eye-open"></span>
                         </div>
                     </div>
                     <div class="col-sm-2 col-sm-offset-1">
-                        <div class="countBox danger">
+                        <div class="countBox danger" id="danger">
                             <h2>{{Total_Fail_Count}}</h2>
                             Failed Tests
+                            <span class="glyphicon glyphicon-eye-open"></span>
                         </div>
                     </div>
                     <div class="col-sm-2 col-sm-offset-1">
-                        <div class="countBox active">
+                        <div class="countBox active" id="active">
                             <h2>{{Total_Skip_Count}}</h2>
                             Skipped Tests
+                            <span class="glyphicon glyphicon-eye-open"></span>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
Added the ability to show/hide the test details by default.
The states get's stored in the local storage of the browser (if local storage is available).
This makes it easy to just monitor the failed test cases